### PR TITLE
Pass basePath to custom block handler

### DIFF
--- a/lib/refManager.js
+++ b/lib/refManager.js
@@ -64,7 +64,7 @@ module.exports = {
     } else if (bb.type === 'remove') {
       ref = '';
     } else if (bb.handler) {
-      ref = bb.handler(blockContent, bb.target, bb.attbs, bb.alternateSearchPaths);
+      ref = bb.handler(blockContent, bb.target, bb.attbs, bb.alternateSearchPaths, options._basePath);
     } else {
       ref = null;
     }


### PR DESCRIPTION
From within useref custom block handlers I need access to the _basePath variable which gulp-useref uses as vfs.glob base, so that I can push files to the stream and they will be output identically to useref internal blocks.

``` javascript
import: function importer (content, target, options, alternateSearchPath, basePath) {
  //...
  let file = new vinyl({
    base: basePath,
    path: target,
    contents: buffer,
  })
  stream.push(file)
  return `<script src="${target}"></script>`
}
```
