### PR TITLE
fix css rel disscussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Blocks are expressed as:
 - **type**: either `js`, `css` or `remove`
 - **alternate search path**: (optional) By default the input files are relative to the treated file. Alternate search path allows one to change that
 - **path**: the file path of the optimized file, the target output
-- **parameters**: extra parameters that should be added to the tag
+- **parameters**: extra parameters that should be added to the tag. By default `rel="stylesheet"` attribute is added to css link tag, your can overwrite it by passing your own rel parameter, e.g. `rel="preload"`
 
 An example of this in completed form can be seen below:
 

--- a/lib/refManager.js
+++ b/lib/refManager.js
@@ -16,17 +16,25 @@ module.exports = {
 
   transformCSSRefs: function (block, target, attbs) {
     var ref = '';
+    var rel = 'rel="stylesheet" ';
 
     // css link element regular expression
     // TODO: Determine if 'href' attribute is present.
     var regcss = /<?link.*?(?:>|\))/gmi;
 
+    // rel attribute regular expression
+    var regrel = /(^|\s)rel=/i;
+    // if rel exists in attributes, set the default one empty
+    if (regrel.test(attbs)) {
+      rel = '';
+    }
+
     // Check to see if there are any css references at all.
     if (block.search(regcss) !== -1) {
       if (attbs) {
-        ref = '<link rel="stylesheet" href="' + target + '" ' + attbs + '>';
+        ref = '<link ' + rel + 'href="' + target + '" ' + attbs + '>';
       } else {
-        ref = '<link rel="stylesheet" href="' + target + '">';
+        ref = '<link ' + rel + 'href="' + target + '">';
       }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,12 @@ describe('html-ref-replace', function() {
     expect(result[1]).to.eql({ css: { '/css/combined.css': { 'assets': [ '/css/one.css', '/css/two.css' ] }}});
   });
 
+  it('should replace css blocks with rel', function() {
+    var result = useRef(fread(djoin('testfiles/15-rel.html')));
+    expect(result[0]).to.equal(fread(djoin('testfiles/15-rel-expected.html')));
+    expect(result[1]).to.eql({ css: { '/css/combined.css': { 'assets': [ '/css/one.css', '/css/two.css' ] }}});
+  });
+
   it('should reserve IE conditional comments', function() {
     var result = useRef(fread(djoin('testfiles/16.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/16-expected.html')));

--- a/test/testfiles/15-rel-expected.html
+++ b/test/testfiles/15-rel-expected.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+  <link href="/css/combined.css" rel="preload" media="print">
+</head>
+</html>

--- a/test/testfiles/15-rel.html
+++ b/test/testfiles/15-rel.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <!-- build:css /css/combined.css rel="preload" media="print" -->
+  <link href="/css/one.css" rel="preload" media="print">
+  <link href="/css/two.css" rel="preload" media="print">
+  <!-- endbuild -->
+</head>
+</html>


### PR DESCRIPTION
If user defined `rel` attribute such as `preload`, we should remove the default `stylesheet` rel.