### PR TITLE
Add handler to parse source and transform target paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Works with the [symfony2 assetic](http://symfony.com/doc/current/cookbook/asseti
 #### options.noconcat
 
 Type: `Boolean`  
-Default: `false`  
+Default: `false`
 
 Strips out build comments but leaves the rest of the block intact without replacing any tags.
 
@@ -190,6 +190,29 @@ Results in:
 <script type="text/javascript" src="scripts/this.js"></script>
 <script type="text/javascript" src="scripts/that.js"></script>
 ```
+
+#### options.parseSourcePath
+
+Type: `Function`
+Return: The path to the source file
+
+Function to parse the source path out of a script or style element.
+
+The function gets the following arguments:
+- *tag* (String): The html script or style tag
+- *type*: (String): The type e.g. `js`, `css`
+
+#### options.transformTargetPath
+
+Type: `Function`
+Return: The transformed path to the target file
+
+Function to transform the target file path.
+
+The function gets the following arguments:
+
+- *target* (String): The path to the target file
+- *type*: (String): The type e.g. `js`, `css`
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (content, options) {
   var blocks = getBlocks(content),
     opts = options || {},
     transformedContent = transformReferences(blocks, content, opts),
-    replaced = compactContent(blocks);
+    replaced = compactContent(blocks, opts);
 
   return [ transformedContent, replaced ];
 };

--- a/lib/compactContent.js
+++ b/lib/compactContent.js
@@ -9,9 +9,12 @@ function removeComments(lines) {
   return lines.join('\n').replace(regComment, '').split('\n');
 }
 
-module.exports = function (blocks) {
+module.exports = function (blocks, options) {
 
-  var result = {};
+  var result = {},
+    parseSourcePath = options.parseSourcePath || function (tag) {
+      return (tag.match(/(href|src)=(?:["']\W+\s*(?:\w+)\()?["']([^'"]+)['"]/) || [])[2];
+    };
 
   Object.keys(blocks).forEach(function (dest) {
     // Lines are the included scripts w/o the use blocks
@@ -27,11 +30,14 @@ module.exports = function (blocks) {
     // remove html comment blocks
     lines = removeComments(lines);
 
-    // parse out the list of assets to handle, and update the grunt config accordingly
+    // parse out the list of assets to handle, and update the config accordingly
     assets = lines.map(function (tag) {
-      // Allow white space and comment in build blocks by checking if this line has an asset or not
-      // The asset is the string of the referenced source file
-      return (tag.match(/(href|src)=(?:["']\W+\s*(?:\w+)\()?["']([^'"]+)['"]/) || [])[2];
+      if (typeof(parseSourcePath) !== 'function') {
+        throw new Error('options.parseSourcePath must be a function');
+      }
+
+      // call function to parse the asset path
+      return parseSourcePath(tag, type);
     }).reduce(function (a, b) {
       return b ? a.concat(b) : a;
     }, []);

--- a/lib/refManager.js
+++ b/lib/refManager.js
@@ -5,13 +5,19 @@ var parseBuildBlock = require('./parseBuildBlock'),
 
 module.exports = {
   setBuildBlock: function (block, options) {
-    var props = parseBuildBlock(block);
+    var props = parseBuildBlock(block),
+      transformTargetPath = options.transformTargetPath;
 
     bb.handler = options && options[props.type];
     bb.target = props.target || 'replace';
     bb.type = props.type;
     bb.attbs = props.attbs;
     bb.alternateSearchPaths = props.alternateSearchPaths;
+
+    // transform target file path
+    if (typeof(transformTargetPath) === 'function') {
+      bb.target = transformTargetPath(bb.target, bb.type);
+    }
   },
 
   transformCSSRefs: function (block, target, attbs) {

--- a/test/test.js
+++ b/test/test.js
@@ -254,4 +254,23 @@ describe('html-ref-replace', function() {
       }
     });
   });
+
+  it('should parse and transform source and target path', function () {
+    var result = useRef(fread(djoin('testfiles/28.html')), {
+      parseSourcePath: function (tag) {
+        return (tag.match(/(src|href)\s*=\s*['"]\$\{url\('([^']+)'\)\}['"]/) || [])[2];
+      },
+      transformTargetPath: function(target) {
+        return '${url(\'' + target + '\')}';
+      }
+    });
+    expect(result[0]).to.equal(fread(djoin('testfiles/28-expected.html')));
+    expect(result[1]).to.eql({
+      js: {
+        '/js/combined.js': {
+          'assets': [ '/js/script1.js', '/js/script2.js' ],
+        },
+      }
+    });
+  });
 });

--- a/test/testfiles/28-expected.html
+++ b/test/testfiles/28-expected.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+<script src="${url('/js/combined.js')}"></script>
+</body>
+</html>

--- a/test/testfiles/28.html
+++ b/test/testfiles/28.html
@@ -1,0 +1,9 @@
+<html>
+<head></head>
+<body>
+<!-- build:js /js/combined.js -->
+<script src="${url('/js/script1.js')}"></script>
+<script src="${url('/js/script2.js')}"></script>
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
This PR introduces two new options (handler functions) to parse source and transform target paths. We use a template engine where the paths to the resources are generate at runtime and therefore it's necessary to modify the paths before processing. I've added a test to show a possible use-case.

#### options.parseSourcePath

Type: `Function`
Return: The path to the source file

Function to parse the source path out of a script or style element.

The function gets the following arguments:
- *tag* (String): The html script or style tag
- *type*: (String): The type e.g. `js`, `css`

#### options.transformTargetPath

Type: `Function`
Return: The transformed path to the target file

Function to transform the target file path.

The function gets the following arguments:

- *target* (String): The path to the target file
- *type*: (String): The type e.g. `js`, `css`